### PR TITLE
fix: hype train last contribution should be single object

### DIFF
--- a/TwitchLib.EventSub.Webhooks/Core/SubscriptionTypes/Channel/HypeTrainBegin.cs
+++ b/TwitchLib.EventSub.Webhooks/Core/SubscriptionTypes/Channel/HypeTrainBegin.cs
@@ -21,7 +21,7 @@ namespace TwitchLib.EventSub.Webhooks.Core.SubscriptionTypes.Channel
         /// <summary>
         /// The most recent contribution.
         /// </summary>
-        public HypeTrainContribution[] LastContribution { get; set; } = Array.Empty<HypeTrainContribution>();
+        public HypeTrainContribution LastContribution { get; set; }
         /// <summary>
         /// The time when the Hype Train expires. The expiration is extended when the Hype Train reaches a new level.
         /// </summary>


### PR DESCRIPTION
Fixes #2 

https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelhype_trainbegin
