### PR TITLE
Add Chat Eventsub Handling

### DIFF
--- a/TwitchLib.EventSub.Webhooks/Core/EventArgs/Channel/ChannelChatClearArgs.cs
+++ b/TwitchLib.EventSub.Webhooks/Core/EventArgs/Channel/ChannelChatClearArgs.cs
@@ -1,0 +1,8 @@
+﻿using TwitchLib.EventSub.Webhooks.Core.Models;
+using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Webhooks.Core.EventArgs.Channel
+{
+    public class ChannelChatClearArgs : TwitchLibEventSubEventArgs<EventSubNotificationPayload<ChannelChatClear>>
+    { }
+}

--- a/TwitchLib.EventSub.Webhooks/Core/EventArgs/Channel/ChannelChatClearUserMessageArgs.cs
+++ b/TwitchLib.EventSub.Webhooks/Core/EventArgs/Channel/ChannelChatClearUserMessageArgs.cs
@@ -1,0 +1,8 @@
+﻿using TwitchLib.EventSub.Webhooks.Core.Models;
+using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Webhooks.Core.EventArgs.Channel
+{
+    public class ChannelChatClearUserMessageArgs : TwitchLibEventSubEventArgs<EventSubNotificationPayload<ChannelChatClearUserMessage>>
+    { }
+}

--- a/TwitchLib.EventSub.Webhooks/Core/EventArgs/Channel/ChannelChatMessageArgs.cs
+++ b/TwitchLib.EventSub.Webhooks/Core/EventArgs/Channel/ChannelChatMessageArgs.cs
@@ -1,0 +1,8 @@
+﻿using TwitchLib.EventSub.Webhooks.Core.Models;
+using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Webhooks.Core.EventArgs.Channel
+{
+    public class ChannelChatMessageArgs : TwitchLibEventSubEventArgs<EventSubNotificationPayload<ChannelChatMessage>>
+    { }
+}

--- a/TwitchLib.EventSub.Webhooks/Core/EventArgs/Channel/ChannelChatMessageDeleteArgs.cs
+++ b/TwitchLib.EventSub.Webhooks/Core/EventArgs/Channel/ChannelChatMessageDeleteArgs.cs
@@ -1,0 +1,8 @@
+﻿using TwitchLib.EventSub.Webhooks.Core.Models;
+using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Webhooks.Core.EventArgs.Channel
+{
+    public class ChannelChatMessageDeleteArgs : TwitchLibEventSubEventArgs<EventSubNotificationPayload<ChannelChatMessageDelete>>
+    { }
+}

--- a/TwitchLib.EventSub.Webhooks/Core/EventArgs/Channel/ChannelChatNotificationArgs.cs
+++ b/TwitchLib.EventSub.Webhooks/Core/EventArgs/Channel/ChannelChatNotificationArgs.cs
@@ -1,0 +1,8 @@
+﻿using TwitchLib.EventSub.Webhooks.Core.Models;
+using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
+
+namespace TwitchLib.EventSub.Webhooks.Core.EventArgs.Channel
+{
+    public class ChannelChatNotificationArgs : TwitchLibEventSubEventArgs<EventSubNotificationPayload<ChannelChatNotification>>
+    { }
+}

--- a/TwitchLib.EventSub.Webhooks/Core/IEventSubWebhooks.cs
+++ b/TwitchLib.EventSub.Webhooks/Core/IEventSubWebhooks.cs
@@ -207,11 +207,11 @@ namespace TwitchLib.EventSub.Webhooks.Core
         /// </summary>
         event EventHandler<UserUpdateArgs>? OnUserUpdate;
         /// <summary>
-        /// Event that triggers on "channel.clear" notifications
+        /// Event that triggers on "channel.chat.clear" notifications
         /// </summary>
         event EventHandler<ChannelChatClearArgs>? OnChannelChatClear;
         /// <summary>
-        /// Event that triggers on "channel.clear_user_messages" notifications
+        /// Event that triggers on "channel.chat.clear_user_messages" notifications
         /// </summary>
         event EventHandler<ChannelChatClearUserMessageArgs>? OnChannelChatClearUserMessage;
         /// <summary>

--- a/TwitchLib.EventSub.Webhooks/Core/IEventSubWebhooks.cs
+++ b/TwitchLib.EventSub.Webhooks/Core/IEventSubWebhooks.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using TwitchLib.EventSub.Core.SubscriptionTypes.Channel;
 using TwitchLib.EventSub.Webhooks.Core.EventArgs;
 using TwitchLib.EventSub.Webhooks.Core.EventArgs.Channel;
 using TwitchLib.EventSub.Webhooks.Core.EventArgs.Drop;
@@ -205,6 +206,27 @@ namespace TwitchLib.EventSub.Webhooks.Core
         /// Event that triggers on "user.update" notifications
         /// </summary>
         event EventHandler<UserUpdateArgs>? OnUserUpdate;
+        /// <summary>
+        /// Event that triggers on "channel.clear" notifications
+        /// </summary>
+        event EventHandler<ChannelChatClearArgs>? OnChannelChatClear;
+        /// <summary>
+        /// Event that triggers on "channel.clear_user_messages" notifications
+        /// </summary>
+        event EventHandler<ChannelChatClearUserMessageArgs>? OnChannelChatClearUserMessage;
+        /// <summary>
+        /// Event that triggers on "channel.chat.message" notifications
+        /// </summary>
+        event EventHandler<ChannelChatMessageArgs>? OnChannelChatMessage;
+        /// <summary>
+        /// Event that triggers on "channel.chat.message_delete" notifications
+        /// </summary>
+        event EventHandler<ChannelChatMessageDeleteArgs>? OnChannelChatMessageDelete;
+        /// <summary>
+        /// Event that triggers on "channel.chat.notification" notifications
+        /// </summary>
+        event EventHandler<ChannelChatNotificationArgs>? OnChannelChatNotification;
+        
 
         /// <summary>
         /// Processes "notification" type messages. You should not use this in your code, its for internal use only!

--- a/TwitchLib.EventSub.Webhooks/EventSubWebhooks.cs
+++ b/TwitchLib.EventSub.Webhooks/EventSubWebhooks.cs
@@ -129,6 +129,16 @@ namespace TwitchLib.EventSub.Webhooks
         public event EventHandler<UserAuthorizationRevokeArgs>? OnUserAuthorizationRevoke;
         /// <inheritdoc/>
         public event EventHandler<UserUpdateArgs>? OnUserUpdate;
+        /// <inheritdoc/>
+        public event EventHandler<ChannelChatClearArgs>? OnChannelChatClear;
+        /// <inheritdoc/>
+        public event EventHandler<ChannelChatClearUserMessageArgs>? OnChannelChatClearUserMessage;
+        /// <inheritdoc/>
+        public event EventHandler<ChannelChatMessageArgs>? OnChannelChatMessage;
+        /// <inheritdoc/>
+        public event EventHandler<ChannelChatMessageDeleteArgs>? OnChannelChatMessageDelete;
+        /// <inheritdoc/>
+        public event EventHandler<ChannelChatNotificationArgs>? OnChannelChatNotification;
 
         /// <inheritdoc/>
         public async Task ProcessNotificationAsync(Dictionary<string, string> headers, Stream body)
@@ -322,6 +332,26 @@ namespace TwitchLib.EventSub.Webhooks
                     case "user.update":
                         var userUpdateNotification = await JsonSerializer.DeserializeAsync<EventSubNotificationPayload<UserUpdate>>(body, _jsonSerializerOptions);
                         OnUserUpdate?.Invoke(this, new UserUpdateArgs { Headers = headers, Notification = userUpdateNotification! });
+                        break;
+                    case "channel.chat.clear":
+                        var channelChatClearNotification = await JsonSerializer.DeserializeAsync<EventSubNotificationPayload<ChannelChatClear>>(body, _jsonSerializerOptions);
+                        OnChannelChatClear?.Invoke(this, new ChannelChatClearArgs { Headers = headers, Notification = channelChatClearNotification! });
+                        break;
+                    case "channel.chat.clear_user_messages":
+                        var channelChatClearUserMessageNotification = await JsonSerializer.DeserializeAsync<EventSubNotificationPayload<ChannelChatClearUserMessage>>(body, _jsonSerializerOptions);
+                        OnChannelChatClearUserMessage?.Invoke(this, new ChannelChatClearUserMessageArgs() { Headers = headers, Notification = channelChatClearUserMessageNotification! });
+                        break;
+                    case "channel.chat.message":
+                        var channelChatMessageNotification = await JsonSerializer.DeserializeAsync<EventSubNotificationPayload<ChannelChatMessage>>(body, _jsonSerializerOptions);
+                        OnChannelChatMessage?.Invoke(this, new ChannelChatMessageArgs { Headers = headers, Notification = channelChatMessageNotification! });
+                        break;
+                    case "channel.chat.message_delete":
+                        var channelChatMessageDeleteNotification = await JsonSerializer.DeserializeAsync<EventSubNotificationPayload<ChannelChatMessageDelete>>(body, _jsonSerializerOptions);
+                        OnChannelChatMessageDelete?.Invoke(this, new ChannelChatMessageDeleteArgs { Headers = headers, Notification = channelChatMessageDeleteNotification! });
+                        break;
+                    case "channel.chat.notification":
+                        var channelChatNotificationNotification = await JsonSerializer.DeserializeAsync<EventSubNotificationPayload<ChannelChatNotification>>(body, _jsonSerializerOptions);
+                        OnChannelChatNotification?.Invoke(this, new ChannelChatNotificationArgs { Headers = headers, Notification = channelChatNotificationNotification! });
                         break;
                     default:
                         OnError?.Invoke(this, new OnErrorArgs { Reason = "Unknown_Subscription_Type", Message = $"Cannot parse unknown subscription type {subscriptionType}" });

--- a/TwitchLib.EventSub.Webhooks/TwitchLib.EventSub.Webhooks.csproj
+++ b/TwitchLib.EventSub.Webhooks/TwitchLib.EventSub.Webhooks.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="TwitchLib.EventSub.Core" Version="2.3.0" />
+    <PackageReference Include="TwitchLib.EventSub.Core" Version="2.5.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since Twitch is moving away from IRC:

- updated TwitchLib.EventSub.Core dependency requirement to v2.5.2
- added the new [channel chat eventsub events](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelchatmessage) 