### PR TITLE
removed deprecated .NET versions & performance improvements

### DIFF
--- a/TwitchLib.EventSub.Webhooks.Test/TwitchLib.EventSub.Webhooks.Test.csproj
+++ b/TwitchLib.EventSub.Webhooks.Test/TwitchLib.EventSub.Webhooks.Test.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>TwitchLib.EventSub.Webhooks.Test</RootNamespace>
+    <TargetFramework>net8.0</TargetFramework>
+    <!--
+    To enable the Microsoft Testing Platform 'dotnet test' experience, add property:
+      <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+
+    To enable the Microsoft Testing Platform native command line experience, add property:
+      <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+
+    For more information on Microsoft Testing Platform support in xUnit.net, please visit:
+      https://xunit.net/docs/getting-started/v3/microsoft-testing-platform
+    -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit.v3" Version="2.0.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TwitchLib.EventSub.Webhooks\TwitchLib.EventSub.Webhooks.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TwitchLib.EventSub.Webhooks.Test/UnitTest1.cs
+++ b/TwitchLib.EventSub.Webhooks.Test/UnitTest1.cs
@@ -13,7 +13,7 @@ public class UnitTest1
         var messageBody = """
                     {"subscription":{"id":"d5b930eb-5333-a535-0e38-603bc2a22ce1","status":"enabled","type":"stream.offline","version":"1","condition":{"broadcaster_user_id":"88922321"},"transport":{"method":"webhook","callback":"null"},"created_at":"2025-05-11T20:13:00.4746258Z","cost":0},"event":{"broadcaster_user_id":"88922321","broadcaster_user_login":"testBroadcaster","broadcaster_user_name":"testBroadcaster"}}
                     """;
-        var secret = "supersecuresecret"u8.ToArray();
+        var secret = "supersecuresecret"u8;
 
         Assert.True(EventSubSignatureVerificationMiddleware.IsSignatureValid(messageSignature, messageId, messageTimestamp, messageBody, secret));
     }

--- a/TwitchLib.EventSub.Webhooks.Test/UnitTest1.cs
+++ b/TwitchLib.EventSub.Webhooks.Test/UnitTest1.cs
@@ -1,0 +1,20 @@
+using TwitchLib.EventSub.Webhooks.Middlewares;
+
+namespace TwitchLib.EventSub.Webhooks.Test;
+
+public class UnitTest1
+{
+    [Fact]
+    public void SignatureVerification_Succeeded()
+    {
+        var messageId = "65e98bd4-a057-11cd-187a-75e8f5b3fb89";
+        var messageTimestamp = "2025-05-11T20:13:00.4746258Z";
+        var messageSignature = "sha256=d821508901727be752420bbd78366545d6da62e68b101f38d37574bfbe2b627c";
+        var messageBody = """
+                    {"subscription":{"id":"d5b930eb-5333-a535-0e38-603bc2a22ce1","status":"enabled","type":"stream.offline","version":"1","condition":{"broadcaster_user_id":"88922321"},"transport":{"method":"webhook","callback":"null"},"created_at":"2025-05-11T20:13:00.4746258Z","cost":0},"event":{"broadcaster_user_id":"88922321","broadcaster_user_login":"testBroadcaster","broadcaster_user_name":"testBroadcaster"}}
+                    """;
+        var secret = "supersecuresecret"u8.ToArray();
+
+        Assert.True(EventSubSignatureVerificationMiddleware.IsSignatureValid(messageSignature, messageId, messageTimestamp, messageBody, secret));
+    }
+}

--- a/TwitchLib.EventSub.Webhooks.Test/xunit.runner.json
+++ b/TwitchLib.EventSub.Webhooks.Test/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}

--- a/TwitchLib.EventSub.Webhooks.sln
+++ b/TwitchLib.EventSub.Webhooks.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31410.223
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35931.197
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchLib.EventSub.Webhooks", "TwitchLib.EventSub.Webhooks\TwitchLib.EventSub.Webhooks.csproj", "{6176B27E-E417-41C8-BDEE-CB09FD342CA5}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchLib.EventSub.Webhooks.Example", "TwitchLib.EventSub.Webhooks.Example\TwitchLib.EventSub.Webhooks.Example.csproj", "{26079F7D-9C72-43F9-BCAC-AD7E96AAC5C3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TwitchLib.EventSub.Webhooks.Test", "TwitchLib.EventSub.Webhooks.Test\TwitchLib.EventSub.Webhooks.Test.csproj", "{6951CCDA-242A-8652-D81D-F20D8EF8FD9F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{26079F7D-9C72-43F9-BCAC-AD7E96AAC5C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{26079F7D-9C72-43F9-BCAC-AD7E96AAC5C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{26079F7D-9C72-43F9-BCAC-AD7E96AAC5C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6951CCDA-242A-8652-D81D-F20D8EF8FD9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6951CCDA-242A-8652-D81D-F20D8EF8FD9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6951CCDA-242A-8652-D81D-F20D8EF8FD9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6951CCDA-242A-8652-D81D-F20D8EF8FD9F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TwitchLib.EventSub.Webhooks/AssemblyInfo.cs
+++ b/TwitchLib.EventSub.Webhooks/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("TwitchLib.EventSub.Webhooks.Test")]

--- a/TwitchLib.EventSub.Webhooks/EventSubWebhooks.cs
+++ b/TwitchLib.EventSub.Webhooks/EventSubWebhooks.cs
@@ -354,6 +354,7 @@ namespace TwitchLib.EventSub.Webhooks
                     case "channel.chat.notification":
                         var channelChatNotificationNotification = await JsonSerializer.DeserializeAsync<EventSubNotificationPayload<ChannelChatNotification>>(body, _jsonSerializerOptions);
                         OnChannelChatNotification?.Invoke(this, new ChannelChatNotificationArgs { Headers = headers, Notification = channelChatNotificationNotification! });
+                        break;
                     case "user.whisper.message":
                         var userWhisperMessage = await JsonSerializer.DeserializeAsync<EventSubNotificationPayload<UserWhisperMessage>>(body, _jsonSerializerOptions);
                         OnUserWhisperMessage?.Invoke(this, new UserWhisperMessageArgs { Headers = headers, Notification = userWhisperMessage! });

--- a/TwitchLib.EventSub.Webhooks/Middlewares/EventSubNotificationLoggerMiddleware.cs
+++ b/TwitchLib.EventSub.Webhooks/Middlewares/EventSubNotificationLoggerMiddleware.cs
@@ -20,11 +20,10 @@ namespace TwitchLib.EventSub.Webhooks.Middlewares
 
         public async Task InvokeAsync(HttpContext context)
         {
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
+            var startTimestamp= Stopwatch.GetTimestamp();
             await _next(context);
-            stopwatch.Stop();
-            _logger.LogEventSubHttpNotification(context.Request.Path, context.Response.StatusCode, stopwatch.Elapsed.TotalMilliseconds);
+            var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
+            _logger.LogEventSubHttpNotification(context.Request.Path, context.Response.StatusCode, elapsed.TotalMilliseconds);
         }
     }
 }

--- a/TwitchLib.EventSub.Webhooks/TwitchLib.EventSub.Webhooks.csproj
+++ b/TwitchLib.EventSub.Webhooks/TwitchLib.EventSub.Webhooks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <PackageId>TwitchLib.EventSub.Webhooks</PackageId>
     <Authors>swiftyspiffy, Prom3theu5, Syzuna, LuckyNoS7evin</Authors>
     <PackageTags>twitchlib;twitch,eventsub;webhooks</PackageTags>
@@ -30,7 +30,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.0" />
     <PackageReference Include="TwitchLib.EventSub.Core" Version="2.5.3-preview-558d8a5" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR is made from 2 commits.
In the first commit, I only modified the code to be able to test the signature verification function (`IsSignatureValid`).
In the second commit, I made changes to improve performance (below is a benchmark that measures the performance of `IsSignatureValid` before and after the changes) and removed deprecated versions of .NET.

```
| Method                  | Mean       | Error    | StdDev   | Gen0   | Allocated |
|------------------------ |-----------:|---------:|---------:|-------:|----------:|
| IsSignatureValid_Old    | 3,351.4 ns | 63.17 ns | 59.09 ns | 0.0725 |    4424 B |
| IsSignatureValid_New    |   906.9 ns | 16.50 ns | 15.44 ns |      - |      56 B |
```

