### PR TITLE
add handling for unknow events

### DIFF
--- a/TwitchLib.EventSub.Webhooks.Example/EventSubHostedService.cs
+++ b/TwitchLib.EventSub.Webhooks.Example/EventSubHostedService.cs
@@ -18,6 +18,7 @@ namespace TwitchLib.EventSub.Webhooks.Example
         public Task StartAsync(CancellationToken cancellationToken)
         {
             _eventSubWebhooks.OnError += OnError;
+            _eventSubWebhooks.UnknownEventSubEvent += OnUnknownEventSubEvent;
             _eventSubWebhooks.OnChannelFollow += OnChannelFollow;
             return Task.CompletedTask;
         }
@@ -25,6 +26,7 @@ namespace TwitchLib.EventSub.Webhooks.Example
         public Task StopAsync(CancellationToken cancellationToken)
         {
             _eventSubWebhooks.OnError -= OnError;
+            _eventSubWebhooks.UnknownEventSubEvent += OnUnknownEventSubEvent;
             _eventSubWebhooks.OnChannelFollow -= OnChannelFollow;
             return Task.CompletedTask;
         }
@@ -37,6 +39,19 @@ namespace TwitchLib.EventSub.Webhooks.Example
         private async Task OnError(object? sender, OnErrorArgs e)
         {
             _logger.LogError($"Reason: {e.Reason} - Message: {e.Message}");
+        }
+
+        // Handling events that are not (yet) implemented
+        private async Task OnUnknownEventSubEvent(object sender, UnknownEventSubEventArgs e)
+        {
+            var subscription = e.Notification.Subscription;
+            _logger.LogInformation("Received event that has not yet been implemented: type:{type}, version:{version}", subscription.Type, subscription.Version);
+
+            switch ((subscription.Type, subscription.Version))
+            {
+                case ("channel.chat.message", "1"): /*code to handle the event*/ break;
+                default: break;
+            }
         }
     }
 }

--- a/TwitchLib.EventSub.Webhooks.Example/EventSubHostedService.cs
+++ b/TwitchLib.EventSub.Webhooks.Example/EventSubHostedService.cs
@@ -18,7 +18,7 @@ namespace TwitchLib.EventSub.Webhooks.Example
         public Task StartAsync(CancellationToken cancellationToken)
         {
             _eventSubWebhooks.OnError += OnError;
-            _eventSubWebhooks.UnknownEventSubEvent += OnUnknownEventSubEvent;
+            _eventSubWebhooks.UnknownEventSubNotification += OnUnknownEventSubNotification;
             _eventSubWebhooks.OnChannelFollow += OnChannelFollow;
             return Task.CompletedTask;
         }
@@ -26,7 +26,7 @@ namespace TwitchLib.EventSub.Webhooks.Example
         public Task StopAsync(CancellationToken cancellationToken)
         {
             _eventSubWebhooks.OnError -= OnError;
-            _eventSubWebhooks.UnknownEventSubEvent += OnUnknownEventSubEvent;
+            _eventSubWebhooks.UnknownEventSubNotification += OnUnknownEventSubNotification;
             _eventSubWebhooks.OnChannelFollow -= OnChannelFollow;
             return Task.CompletedTask;
         }
@@ -41,8 +41,8 @@ namespace TwitchLib.EventSub.Webhooks.Example
             _logger.LogError($"Reason: {e.Reason} - Message: {e.Message}");
         }
 
-        // Handling events that are not (yet) implemented
-        private async Task OnUnknownEventSubEvent(object sender, UnknownEventSubEventArgs e)
+        // Handling notifications that are not (yet) implemented
+        private async Task OnUnknownEventSubNotification(object sender, UnknownEventSubNotificationArgs e)
         {
             var subscription = e.Notification.Subscription;
             _logger.LogInformation("Received event that has not yet been implemented: type:{type}, version:{version}", subscription.Type, subscription.Version);

--- a/TwitchLib.EventSub.Webhooks/Core/EventArgs/UnknownEventSubEventArgs.cs
+++ b/TwitchLib.EventSub.Webhooks/Core/EventArgs/UnknownEventSubEventArgs.cs
@@ -1,0 +1,7 @@
+﻿using System.Text.Json;
+using TwitchLib.EventSub.Webhooks.Core.Models;
+
+namespace TwitchLib.EventSub.Webhooks.Core.EventArgs;
+
+public class UnknownEventSubEventArgs : TwitchLibEventSubEventArgs<EventSubNotificationPayload<JsonElement>>
+{ }

--- a/TwitchLib.EventSub.Webhooks/Core/EventArgs/UnknownEventSubNotificationArgs.cs
+++ b/TwitchLib.EventSub.Webhooks/Core/EventArgs/UnknownEventSubNotificationArgs.cs
@@ -3,5 +3,5 @@ using TwitchLib.EventSub.Webhooks.Core.Models;
 
 namespace TwitchLib.EventSub.Webhooks.Core.EventArgs;
 
-public class UnknownEventSubEventArgs : TwitchLibEventSubEventArgs<EventSubNotificationPayload<JsonElement>>
+public class UnknownEventSubNotificationArgs : TwitchLibEventSubEventArgs<EventSubNotificationPayload<JsonElement>>
 { }

--- a/TwitchLib.EventSub.Webhooks/Core/IEventSubWebhooks.cs
+++ b/TwitchLib.EventSub.Webhooks/Core/IEventSubWebhooks.cs
@@ -21,9 +21,9 @@ namespace TwitchLib.EventSub.Webhooks.Core
     public interface IEventSubWebhooks
     {
         /// <summary>
-        /// Event that triggers when EventSub send event, that's unknown. (ie.: not implementet ... yet!)
+        /// Event that triggers when EventSub send notification, that's unknown. (ie.: not implementet ... yet!)
         /// </summary>
-        event AsyncEventHandler<UnknownEventSubEventArgs>? UnknownEventSubEvent;
+        event AsyncEventHandler<UnknownEventSubNotificationArgs>? UnknownEventSubNotification;
         /// <summary>
         /// Event that triggers on "automod.message.hold" notifications
         /// </summary>

--- a/TwitchLib.EventSub.Webhooks/Core/IEventSubWebhooks.cs
+++ b/TwitchLib.EventSub.Webhooks/Core/IEventSubWebhooks.cs
@@ -21,6 +21,10 @@ namespace TwitchLib.EventSub.Webhooks.Core
     public interface IEventSubWebhooks
     {
         /// <summary>
+        /// Event that triggers when EventSub send event, that's unknown. (ie.: not implementet ... yet!)
+        /// </summary>
+        event AsyncEventHandler<UnknownEventSubEventArgs>? UnknownEventSubEvent;
+        /// <summary>
         /// Event that triggers on "automod.message.hold" notifications
         /// </summary>
         event AsyncEventHandler<AutomodMessageHoldArgs>? AutomodMessageHold;

--- a/TwitchLib.EventSub.Webhooks/EventSubWebhooks.cs
+++ b/TwitchLib.EventSub.Webhooks/EventSubWebhooks.cs
@@ -39,7 +39,7 @@ namespace TwitchLib.EventSub.Webhooks
         };
 
         /// <inheritdoc/>
-        public event AsyncEventHandler<UnknownEventSubEventArgs>? UnknownEventSubEvent;
+        public event AsyncEventHandler<UnknownEventSubNotificationArgs>? UnknownEventSubNotification;
         /// <inheritdoc/>
         public event AsyncEventHandler<AutomodMessageHoldArgs>? AutomodMessageHold;
         /// <inheritdoc/>
@@ -371,7 +371,7 @@ namespace TwitchLib.EventSub.Webhooks
                         await InvokeEventSubEvent<UserWhisperMessageArgs, EventSubNotificationPayload<UserWhisperMessage>>(OnUserWhisperMessage);
                         break;
                     default:
-                        await InvokeEventSubEvent<UnknownEventSubEventArgs, EventSubNotificationPayload<JsonElement>>(UnknownEventSubEvent);
+                        await InvokeEventSubEvent<UnknownEventSubNotificationArgs, EventSubNotificationPayload<JsonElement>>(UnknownEventSubNotification);
                         break;
                 }
             }

--- a/TwitchLib.EventSub.Webhooks/EventSubWebhooks.cs
+++ b/TwitchLib.EventSub.Webhooks/EventSubWebhooks.cs
@@ -39,6 +39,8 @@ namespace TwitchLib.EventSub.Webhooks
         };
 
         /// <inheritdoc/>
+        public event AsyncEventHandler<UnknownEventSubEventArgs>? UnknownEventSubEvent;
+        /// <inheritdoc/>
         public event AsyncEventHandler<AutomodMessageHoldArgs>? AutomodMessageHold;
         /// <inheritdoc/>
         public event AsyncEventHandler<AutomodMessageHoldV2Args>? AutomodMessageHoldV2;
@@ -369,7 +371,7 @@ namespace TwitchLib.EventSub.Webhooks
                         await InvokeEventSubEvent<UserWhisperMessageArgs, EventSubNotificationPayload<UserWhisperMessage>>(OnUserWhisperMessage);
                         break;
                     default:
-                        await OnError.InvokeAsync(this, new OnErrorArgs { Reason = "Unknown_Subscription_Type", Message = $"Cannot parse unknown subscription type {subscriptionType}/{subscriptionVersion}" });
+                        await InvokeEventSubEvent<UnknownEventSubEventArgs, EventSubNotificationPayload<JsonElement>>(UnknownEventSubEvent);
                         break;
                 }
             }


### PR DESCRIPTION
Changes:
Added a new `UnknownEventSubEvent` event to handle new EventSub events/notifications that have not (yet) been implemented (so users will be able to use the latest events/notifications even if the NuGet package is "out of date".