### PR TITLE
Crosspackage improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ You only need a few lines of code to add and configure it.
 ## Breaking Changes in Version 3.0
 - Removed deprecated versions of .NET.
 - Events are now asynchronous (return value changed from `void` to `Task`)
+- Events dropped the `On` prefix (`OnChannelChatMessage` => `ChannelChatMessage`)
 
 ## Breaking Changes in Version 2.0
 

--- a/TwitchLib.EventSub.Webhooks.Example/EventSubHostedService.cs
+++ b/TwitchLib.EventSub.Webhooks.Example/EventSubHostedService.cs
@@ -17,17 +17,17 @@ namespace TwitchLib.EventSub.Webhooks.Example
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
-            _eventSubWebhooks.OnError += OnError;
+            _eventSubWebhooks.Error += OnError;
             _eventSubWebhooks.UnknownEventSubNotification += OnUnknownEventSubNotification;
-            _eventSubWebhooks.OnChannelFollow += OnChannelFollow;
+            _eventSubWebhooks.ChannelFollow += OnChannelFollow;
             return Task.CompletedTask;
         }
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            _eventSubWebhooks.OnError -= OnError;
+            _eventSubWebhooks.Error -= OnError;
             _eventSubWebhooks.UnknownEventSubNotification += OnUnknownEventSubNotification;
-            _eventSubWebhooks.OnChannelFollow -= OnChannelFollow;
+            _eventSubWebhooks.ChannelFollow -= OnChannelFollow;
             return Task.CompletedTask;
         }
 

--- a/TwitchLib.EventSub.Webhooks/Core/EventArgs/TwitchLibEventSubEventArgs.cs
+++ b/TwitchLib.EventSub.Webhooks/Core/EventArgs/TwitchLibEventSubEventArgs.cs
@@ -1,10 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using TwitchLib.EventSub.Webhooks.Core.Models;
 
 namespace TwitchLib.EventSub.Webhooks.Core.EventArgs
 {
     public abstract class TwitchLibEventSubEventArgs<T> : System.EventArgs where T: new()
     {
-        public Dictionary<string, string> Headers { get; set; } = new();
+        public WebhookEventSubMetadata Metadata { get; set; } = new();
         public T Notification { get; set; } = new();
     }
 }

--- a/TwitchLib.EventSub.Webhooks/Core/IEventSubWebhooks.cs
+++ b/TwitchLib.EventSub.Webhooks/Core/IEventSubWebhooks.cs
@@ -20,6 +20,14 @@ namespace TwitchLib.EventSub.Webhooks.Core
     public interface IEventSubWebhooks
     {
         /// <summary>
+        /// Event that triggers if an error parsing a notification or revocation was encountered
+        /// </summary>
+        event AsyncEventHandler<OnErrorArgs>? Error;
+        /// <summary>
+        /// Event that triggers on if a revocation notification was received
+        /// </summary>
+        event AsyncEventHandler<RevocationArgs>? Revocation;
+        /// <summary>
         /// Event that triggers when EventSub send notification, that's unknown. (ie.: not implementet ... yet!)
         /// </summary>
         event AsyncEventHandler<UnknownEventSubNotificationArgs>? UnknownEventSubNotification;
@@ -54,55 +62,55 @@ namespace TwitchLib.EventSub.Webhooks.Core
         /// <summary>
         /// Event that triggers on "channel.ban" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelBanArgs>? OnChannelBan;
+        event AsyncEventHandler<ChannelBanArgs>? ChannelBan;
         /// <summary>
         /// Event that triggers on "channel.cheer" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelCheerArgs>? OnChannelCheer;
+        event AsyncEventHandler<ChannelCheerArgs>? ChannelCheer;
         /// <summary>
         /// Event that triggers on "channel.charity_campaign.start" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelCharityCampaignStartArgs>? OnChannelCharityCampaignStart;
+        event AsyncEventHandler<ChannelCharityCampaignStartArgs>? ChannelCharityCampaignStart;
         /// <summary>
         /// Event that triggers on "channel.charity_campaign.donate" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelCharityCampaignDonateArgs>? OnChannelCharityCampaignDonate;
+        event AsyncEventHandler<ChannelCharityCampaignDonateArgs>? ChannelCharityCampaignDonate;
         /// <summary>
         /// Event that triggers on "channel.charity_campaign.progress" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelCharityCampaignProgressArgs>? OnChannelCharityCampaignProgress;
+        event AsyncEventHandler<ChannelCharityCampaignProgressArgs>? ChannelCharityCampaignProgress;
         /// <summary>
         /// Event that triggers on "channel.charity_campaign.stop" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelCharityCampaignStopArgs>? OnChannelCharityCampaignStop;
+        event AsyncEventHandler<ChannelCharityCampaignStopArgs>? ChannelCharityCampaignStop;
         /// <summary>
         /// Event that triggers on "channel.follow" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelFollowArgs>? OnChannelFollow;
+        event AsyncEventHandler<ChannelFollowArgs>? ChannelFollow;
         /// <summary>
         /// Event that triggers on "channel.goal.begin" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelGoalBeginArgs>? OnChannelGoalBegin;
+        event AsyncEventHandler<ChannelGoalBeginArgs>? ChannelGoalBegin;
         /// <summary>
         /// Event that triggers on "channel.goal.end" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelGoalEndArgs>? OnChannelGoalEnd;
+        event AsyncEventHandler<ChannelGoalEndArgs>? ChannelGoalEnd;
         /// <summary>
         /// Event that triggers on "channel.goal.progress" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelGoalProgressArgs>? OnChannelGoalProgress;
+        event AsyncEventHandler<ChannelGoalProgressArgs>? ChannelGoalProgress;
         /// <summary>
         /// Event that triggers on "channel.hype_train.begin" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelHypeTrainBeginV2Args>? OnChannelHypeTrainBeginV2;
+        event AsyncEventHandler<ChannelHypeTrainBeginV2Args>? ChannelHypeTrainBeginV2;
         /// <summary>
         /// Event that triggers on "channel.hype_train.end" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelHypeTrainEndV2Args>? OnChannelHypeTrainEndV2;
+        event AsyncEventHandler<ChannelHypeTrainEndV2Args>? ChannelHypeTrainEndV2;
         /// <summary>
         /// Event that triggers on "channel.hype_train.progress" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelHypeTrainProgressV2Args>? OnChannelHypeTrainProgressV2;
+        event AsyncEventHandler<ChannelHypeTrainProgressV2Args>? ChannelHypeTrainProgressV2;
         /// <summary>
         /// Event that triggers on "channel.moderate" notifications
         /// </summary>
@@ -114,11 +122,11 @@ namespace TwitchLib.EventSub.Webhooks.Core
         /// <summary>
         /// Event that triggers on "channel.moderator.add" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelModeratorArgs>? OnChannelModeratorAdd;
+        event AsyncEventHandler<ChannelModeratorArgs>? ChannelModeratorAdd;
         /// <summary>
         /// Event that triggers on "channel.moderator.remove" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelModeratorArgs>? OnChannelModeratorRemove;
+        event AsyncEventHandler<ChannelModeratorArgs>? ChannelModeratorRemove;
         /// <summary>
         /// Event that triggers on "channel.channel_points_automatic_reward_redemption.add" notifications
         /// </summary>
@@ -130,99 +138,95 @@ namespace TwitchLib.EventSub.Webhooks.Core
         /// <summary>
         /// Event that triggers on "channel.channel_points_custom_reward.add" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelPointsCustomRewardArgs>? OnChannelPointsCustomRewardAdd;
+        event AsyncEventHandler<ChannelPointsCustomRewardArgs>? ChannelPointsCustomRewardAdd;
         /// <summary>
         /// Event that triggers on "channel.channel_points_custom_reward.update" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelPointsCustomRewardArgs>? OnChannelPointsCustomRewardUpdate;
+        event AsyncEventHandler<ChannelPointsCustomRewardArgs>? ChannelPointsCustomRewardUpdate;
         /// <summary>
         /// Event that triggers on "channel.channel_points_custom_reward.remove" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelPointsCustomRewardArgs>? OnChannelPointsCustomRewardRemove;
+        event AsyncEventHandler<ChannelPointsCustomRewardArgs>? ChannelPointsCustomRewardRemove;
         /// <summary>
         /// Event that triggers on "channel.channel_points_custom_reward_redemption.add" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelPointsCustomRewardRedemptionArgs>? OnChannelPointsCustomRewardRedemptionAdd;
+        event AsyncEventHandler<ChannelPointsCustomRewardRedemptionArgs>? ChannelPointsCustomRewardRedemptionAdd;
         /// <summary>
         /// Event that triggers on "channel.channel_points_custom_reward_redemption.update" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelPointsCustomRewardRedemptionArgs>? OnChannelPointsCustomRewardRedemptionUpdate;
+        event AsyncEventHandler<ChannelPointsCustomRewardRedemptionArgs>? ChannelPointsCustomRewardRedemptionUpdate;
         /// <summary>
         /// Event that triggers on "channel.poll.begin" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelPollBeginArgs>? OnChannelPollBegin;
+        event AsyncEventHandler<ChannelPollBeginArgs>? ChannelPollBegin;
         /// <summary>
         /// Event that triggers on "channel.poll.end" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelPollEndArgs>? OnChannelPollEnd;
+        event AsyncEventHandler<ChannelPollEndArgs>? ChannelPollEnd;
         /// <summary>
         /// Event that triggers on "channel.poll.progress" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelPollProgressArgs>? OnChannelPollProgress;
+        event AsyncEventHandler<ChannelPollProgressArgs>? ChannelPollProgress;
         /// <summary>
         /// Event that triggers on "channel.prediction.begin" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelPredictionBeginArgs>? OnChannelPredictionBegin;
+        event AsyncEventHandler<ChannelPredictionBeginArgs>? ChannelPredictionBegin;
         /// <summary>
         /// Event that triggers on "channel.prediction.end" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelPredictionEndArgs>? OnChannelPredictionEnd;
+        event AsyncEventHandler<ChannelPredictionEndArgs>? ChannelPredictionEnd;
         /// <summary>
         /// Event that triggers on "channel.prediction.lock" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelPredictionLockArgs>? OnChannelPredictionLock;
+        event AsyncEventHandler<ChannelPredictionLockArgs>? ChannelPredictionLock;
         /// <summary>
         /// Event that triggers on "channel.prediction.progress" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelPredictionProgressArgs>? OnChannelPredictionProgress;
+        event AsyncEventHandler<ChannelPredictionProgressArgs>? ChannelPredictionProgress;
         /// <summary>
         /// Event that triggers on "channel.raid" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelRaidArgs>? OnChannelRaid;
+        event AsyncEventHandler<ChannelRaidArgs>? ChannelRaid;
         /// <summary>
         /// Event that triggers on "channel.shield_mode.begin" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelShieldModeBeginArgs>? OnChannelShieldModeBegin;
+        event AsyncEventHandler<ChannelShieldModeBeginArgs>? ChannelShieldModeBegin;
         /// <summary>
         /// Event that triggers on "channel.shield_mode.end" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelShieldModeEndArgs>? OnChannelShieldModeEnd;
+        event AsyncEventHandler<ChannelShieldModeEndArgs>? ChannelShieldModeEnd;
         /// <summary>
         /// Event that triggers on "channel.shoutout.create" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelShoutoutCreateArgs>? OnChannelShoutoutCreate;
+        event AsyncEventHandler<ChannelShoutoutCreateArgs>? ChannelShoutoutCreate;
         /// <summary>
         /// Event that triggers on "channel.shoutout.receive" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelShoutoutReceiveArgs>? OnChannelShoutoutReceive;
+        event AsyncEventHandler<ChannelShoutoutReceiveArgs>? ChannelShoutoutReceive;
         /// <summary>
         /// Event that triggers on "channel.subscribe" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelSubscribeArgs>? OnChannelSubscribe;
+        event AsyncEventHandler<ChannelSubscribeArgs>? ChannelSubscribe;
         /// <summary>
         /// Event that triggers on "channel.subscription.end" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelSubscriptionEndArgs>? OnChannelSubscriptionEnd;
+        event AsyncEventHandler<ChannelSubscriptionEndArgs>? ChannelSubscriptionEnd;
         /// <summary>
         /// Event that triggers on "channel.subscription.gift" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelSubscriptionGiftArgs>? OnChannelSubscriptionGift;
+        event AsyncEventHandler<ChannelSubscriptionGiftArgs>? ChannelSubscriptionGift;
         /// <summary>
         /// Event that triggers on "channel.subscription.end" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelSubscriptionMessageArgs>? OnChannelSubscriptionMessage;
+        event AsyncEventHandler<ChannelSubscriptionMessageArgs>? ChannelSubscriptionMessage;
         /// <summary>
         /// Event that triggers on "channel.unban" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelUnbanArgs>? OnChannelUnban;
+        event AsyncEventHandler<ChannelUnbanArgs>? ChannelUnban;
         /// <summary>
         /// Event that triggers on "channel.update" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelUpdateArgs>? OnChannelUpdate;
-        /// <summary>
-        /// Event that triggers if an error parsing a notification or revocation was encountered
-        /// </summary>
-        event AsyncEventHandler<OnErrorArgs>? OnError;
+        event AsyncEventHandler<ChannelUpdateArgs>? ChannelUpdate;
         /// <summary>
         /// Event that triggers on "conduit.shard.disabled" notifications
         /// </summary>
@@ -230,55 +234,51 @@ namespace TwitchLib.EventSub.Webhooks.Core
         /// <summary>
         /// Event that triggers on "drop.entitlement.grant" notifications
         /// </summary>
-        event AsyncEventHandler<DropEntitlementGrantArgs>? OnDropEntitlementGrant;
+        event AsyncEventHandler<DropEntitlementGrantArgs>? DropEntitlementGrant;
         /// <summary>
         /// Event that triggers on "extension.bits_transaction.create" notifications
         /// </summary>
-        event AsyncEventHandler<ExtensionBitsTransactionCreateArgs>? OnExtensionBitsTransactionCreate;
-        /// <summary>
-        /// Event that triggers on if a revocation notification was received
-        /// </summary>
-        event AsyncEventHandler<RevocationArgs>? OnRevocation;
+        event AsyncEventHandler<ExtensionBitsTransactionCreateArgs>? ExtensionBitsTransactionCreate;
         /// <summary>
         /// Event that triggers on "stream.offline" notifications
         /// </summary>
-        event AsyncEventHandler<StreamOfflineArgs>? OnStreamOffline;
+        event AsyncEventHandler<StreamOfflineArgs>? StreamOffline;
         /// <summary>
         /// Event that triggers on "stream.online" notifications
         /// </summary>
-        event AsyncEventHandler<StreamOnlineArgs>? OnStreamOnline;
+        event AsyncEventHandler<StreamOnlineArgs>? StreamOnline;
         /// <summary>
         /// Event that triggers on "user.authorization.grant" notifications
         /// </summary>
-        event AsyncEventHandler<UserAuthorizationGrantArgs>? OnUserAuthorizationGrant;
+        event AsyncEventHandler<UserAuthorizationGrantArgs>? UserAuthorizationGrant;
         /// <summary>
         /// Event that triggers on "user.authorization.revoke" notifications
         /// </summary>
-        event AsyncEventHandler<UserAuthorizationRevokeArgs>? OnUserAuthorizationRevoke;
+        event AsyncEventHandler<UserAuthorizationRevokeArgs>? UserAuthorizationRevoke;
         /// <summary>
         /// Event that triggers on "user.update" notifications
         /// </summary>
-        event AsyncEventHandler<UserUpdateArgs>? OnUserUpdate;
+        event AsyncEventHandler<UserUpdateArgs>? UserUpdate;
         /// <summary>
         /// Event that triggers on "channel.chat.clear" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelChatClearArgs>? OnChannelChatClear;
+        event AsyncEventHandler<ChannelChatClearArgs>? ChannelChatClear;
         /// <summary>
         /// Event that triggers on "channel.chat.clear_user_messages" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelChatClearUserMessageArgs>? OnChannelChatClearUserMessage;
+        event AsyncEventHandler<ChannelChatClearUserMessageArgs>? ChannelChatClearUserMessage;
         /// <summary>
         /// Event that triggers on "channel.chat.message" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelChatMessageArgs>? OnChannelChatMessage;
+        event AsyncEventHandler<ChannelChatMessageArgs>? ChannelChatMessage;
         /// <summary>
         /// Event that triggers on "channel.chat.message_delete" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelChatMessageDeleteArgs>? OnChannelChatMessageDelete;
+        event AsyncEventHandler<ChannelChatMessageDeleteArgs>? ChannelChatMessageDelete;
         /// <summary>
         /// Event that triggers on "channel.chat.notification" notifications
         /// </summary>
-        event AsyncEventHandler<ChannelChatNotificationArgs>? OnChannelChatNotification;
+        event AsyncEventHandler<ChannelChatNotificationArgs>? ChannelChatNotification;
         /// <summary>
         /// Event that triggers on "channel.chat_settings.update" notifications
         /// </summary>

--- a/TwitchLib.EventSub.Webhooks/Core/IEventSubWebhooks.cs
+++ b/TwitchLib.EventSub.Webhooks/Core/IEventSubWebhooks.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using System.Threading.Tasks;
 using TwitchLib.EventSub.Core;
 using TwitchLib.EventSub.Webhooks.Core.EventArgs;
@@ -10,6 +9,7 @@ using TwitchLib.EventSub.Webhooks.Core.EventArgs.Drop;
 using TwitchLib.EventSub.Webhooks.Core.EventArgs.Extension;
 using TwitchLib.EventSub.Webhooks.Core.EventArgs.Stream;
 using TwitchLib.EventSub.Webhooks.Core.EventArgs.User;
+using TwitchLib.EventSub.Webhooks.Core.Models;
 
 namespace TwitchLib.EventSub.Webhooks.Core
 {
@@ -296,14 +296,14 @@ namespace TwitchLib.EventSub.Webhooks.Core
         /// <summary>
         /// Processes "notification" type messages. You should not use this in your code, its for internal use only!
         /// </summary>
-        /// <param name="headers">Dictionary of the request headers</param>
+        /// <param name="metadata">Metadata reveived from the request headers</param>
         /// <param name="body">Stream of the request body</param>
-        Task ProcessNotificationAsync(Dictionary<string, string> headers, Stream body);
+        Task ProcessNotificationAsync(WebhookEventSubMetadata metadata, Stream body);
         /// <summary>
         /// Processes "revocation" type messages. You should not use this in your code, its for internal use only!
         /// </summary>
-        /// <param name="headers">Dictionary of the request headers</param>
+        /// <param name="metadata">Metadata reveived from the request headers</param>
         /// <param name="body">Stream of the request body</param>
-        Task ProcessRevocationAsync(Dictionary<string, string> headers, Stream body);
+        Task ProcessRevocationAsync(WebhookEventSubMetadata metadata, Stream body);
     }
 }

--- a/TwitchLib.EventSub.Webhooks/Core/Models/WebhookEventSubMetadata.cs
+++ b/TwitchLib.EventSub.Webhooks/Core/Models/WebhookEventSubMetadata.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.AspNetCore.Http;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TwitchLib.EventSub.Webhooks.Core.Models;
+
+public class WebhookEventSubMetadata
+{
+    /// <summary>
+    /// An ID that uniquely identifies this message.
+    /// </summary>
+    public string MessageId { get; set; }
+
+    public string MessageRetry { get; set; }
+
+    /// <summary>
+    /// The type of notification.
+    /// </summary>
+    /// <remarks>Possible values are:
+    /// <para>notification — Contains the event's data.</para>
+    /// <para>webhook_callback_verification — Contains the challenge used to verify that you own the event handler.</para>
+    /// <para>revocation — Contains the reason why Twitch revoked your subscription.</para>
+    /// </remarks>
+    public string MessageType { get; set; }
+
+    /// <summary>
+    /// The HMAC signature that you use to verify that Twitch sent the message.
+    /// </summary>
+    public string MessageSignature { get; set; }
+
+    /// <summary>
+    /// The UTC date and time (in RFC3339 format) that Twitch sent the notification.
+    /// </summary>
+    public string MessageTimestamp { get; set; }
+
+    /// <summary>
+    /// The subscription type.
+    /// </summary>
+    public string SubscriptionType { get; set; }
+
+    /// <summary>
+    /// The subscription version.
+    /// </summary>
+    public string SubscriptionVersion { get; set; }
+
+    /// <summary>
+    /// Contains all headers that start with "Twitch-Eventsub-"
+    /// </summary>
+    public Dictionary<string, string> TwitchEventsubHeaders { get; set; }
+
+    internal static WebhookEventSubMetadata CreateMetadata(IHeaderDictionary headers)
+    {
+        return new WebhookEventSubMetadata()
+        {
+            MessageId = headers["Twitch-Eventsub-Message-Id"]!,
+            MessageRetry = headers["Twitch-Eventsub-Message-Retry"]!,
+            MessageType = headers["Twitch-Eventsub-Message-Type"]!,
+            MessageSignature = headers["Twitch-Eventsub-Message-Signature"]!,
+            MessageTimestamp = headers["Twitch-Eventsub-Message-Timestamp"]!,
+            SubscriptionType = headers["Twitch-Eventsub-Subscription-Type"]!,
+            SubscriptionVersion = headers["Twitch-Eventsub-Subscription-Version"]!,
+            TwitchEventsubHeaders = headers.Where(h => !h.Key.StartsWith("Twitch-Eventsub-")).ToDictionary(h => h.Key, h => h.Value.ToString())
+        };
+    }
+}

--- a/TwitchLib.EventSub.Webhooks/Core/Models/WebhookEventSubMetadata.cs
+++ b/TwitchLib.EventSub.Webhooks/Core/Models/WebhookEventSubMetadata.cs
@@ -51,16 +51,19 @@ public class WebhookEventSubMetadata
 
     internal static WebhookEventSubMetadata CreateMetadata(IHeaderDictionary headers)
     {
+        var twitchHeaders = headers.Where(h => h.Key.StartsWith("Twitch-Eventsub-", StringComparison.InvariantCultureIgnoreCase))
+            .ToDictionary(h => h.Key, h => h.Value.ToString());
+
         return new WebhookEventSubMetadata()
         {
-            MessageId = headers["Twitch-Eventsub-Message-Id"]!,
-            MessageRetry = headers["Twitch-Eventsub-Message-Retry"]!,
-            MessageType = headers["Twitch-Eventsub-Message-Type"]!,
-            MessageSignature = headers["Twitch-Eventsub-Message-Signature"]!,
-            MessageTimestamp = headers["Twitch-Eventsub-Message-Timestamp"]!,
-            SubscriptionType = headers["Twitch-Eventsub-Subscription-Type"]!,
-            SubscriptionVersion = headers["Twitch-Eventsub-Subscription-Version"]!,
-            TwitchEventsubHeaders = headers.Where(h => h.Key.StartsWith("Twitch-Eventsub-", StringComparison.InvariantCultureIgnoreCase)).ToDictionary(h => h.Key, h => h.Value.ToString())
+            MessageId = twitchHeaders["Twitch-Eventsub-Message-Id"],
+            MessageRetry = twitchHeaders["Twitch-Eventsub-Message-Retry"],
+            MessageType = twitchHeaders["Twitch-Eventsub-Message-Type"],
+            MessageSignature = twitchHeaders["Twitch-Eventsub-Message-Signature"],
+            MessageTimestamp = twitchHeaders["Twitch-Eventsub-Message-Timestamp"],
+            SubscriptionType = twitchHeaders["Twitch-Eventsub-Subscription-Type"],
+            SubscriptionVersion = twitchHeaders["Twitch-Eventsub-Subscription-Version"],
+            TwitchEventsubHeaders = twitchHeaders
         };
     }
 }

--- a/TwitchLib.EventSub.Webhooks/Core/Models/WebhookEventSubMetadata.cs
+++ b/TwitchLib.EventSub.Webhooks/Core/Models/WebhookEventSubMetadata.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -59,7 +60,7 @@ public class WebhookEventSubMetadata
             MessageTimestamp = headers["Twitch-Eventsub-Message-Timestamp"]!,
             SubscriptionType = headers["Twitch-Eventsub-Subscription-Type"]!,
             SubscriptionVersion = headers["Twitch-Eventsub-Subscription-Version"]!,
-            TwitchEventsubHeaders = headers.Where(h => !h.Key.StartsWith("Twitch-Eventsub-")).ToDictionary(h => h.Key, h => h.Value.ToString())
+            TwitchEventsubHeaders = headers.Where(h => h.Key.StartsWith("Twitch-Eventsub-", StringComparison.InvariantCultureIgnoreCase)).ToDictionary(h => h.Key, h => h.Value.ToString())
         };
     }
 }

--- a/TwitchLib.EventSub.Webhooks/EventSubWebhooks.cs
+++ b/TwitchLib.EventSub.Webhooks/EventSubWebhooks.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -39,6 +38,10 @@ namespace TwitchLib.EventSub.Webhooks
         };
 
         /// <inheritdoc/>
+        public event AsyncEventHandler<OnErrorArgs>? Error;
+        /// <inheritdoc/>
+        public event AsyncEventHandler<RevocationArgs>? Revocation;
+        /// <inheritdoc/>
         public event AsyncEventHandler<UnknownEventSubNotificationArgs>? UnknownEventSubNotification;
         /// <inheritdoc/>
         public event AsyncEventHandler<AutomodMessageHoldArgs>? AutomodMessageHold;
@@ -55,121 +58,117 @@ namespace TwitchLib.EventSub.Webhooks
         /// <inheritdoc/>
         public event AsyncEventHandler<ChannelBitsUseArgs>? ChannelBitsUse;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelBanArgs>? OnChannelBan;
+        public event AsyncEventHandler<ChannelBanArgs>? ChannelBan;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelCheerArgs>? OnChannelCheer;
+        public event AsyncEventHandler<ChannelCheerArgs>? ChannelCheer;
 
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelCharityCampaignStartArgs>? OnChannelCharityCampaignStart;
+        public event AsyncEventHandler<ChannelCharityCampaignStartArgs>? ChannelCharityCampaignStart;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelCharityCampaignDonateArgs>? OnChannelCharityCampaignDonate;
+        public event AsyncEventHandler<ChannelCharityCampaignDonateArgs>? ChannelCharityCampaignDonate;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelCharityCampaignProgressArgs>? OnChannelCharityCampaignProgress;
+        public event AsyncEventHandler<ChannelCharityCampaignProgressArgs>? ChannelCharityCampaignProgress;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelCharityCampaignStopArgs>? OnChannelCharityCampaignStop;
+        public event AsyncEventHandler<ChannelCharityCampaignStopArgs>? ChannelCharityCampaignStop;
 
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelFollowArgs>? OnChannelFollow;
+        public event AsyncEventHandler<ChannelFollowArgs>? ChannelFollow;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelGoalBeginArgs>? OnChannelGoalBegin;
+        public event AsyncEventHandler<ChannelGoalBeginArgs>? ChannelGoalBegin;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelGoalEndArgs>? OnChannelGoalEnd;
+        public event AsyncEventHandler<ChannelGoalEndArgs>? ChannelGoalEnd;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelGoalProgressArgs>? OnChannelGoalProgress;
+        public event AsyncEventHandler<ChannelGoalProgressArgs>? ChannelGoalProgress;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelHypeTrainBeginV2Args>? OnChannelHypeTrainBeginV2;
+        public event AsyncEventHandler<ChannelHypeTrainBeginV2Args>? ChannelHypeTrainBeginV2;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelHypeTrainEndV2Args>? OnChannelHypeTrainEndV2;
+        public event AsyncEventHandler<ChannelHypeTrainEndV2Args>? ChannelHypeTrainEndV2;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelHypeTrainProgressV2Args>? OnChannelHypeTrainProgressV2;
+        public event AsyncEventHandler<ChannelHypeTrainProgressV2Args>? ChannelHypeTrainProgressV2;
         /// <inheritdoc/>
         public event AsyncEventHandler<ChannelModerateArgs>? ChannelModerate;
         /// <inheritdoc/>
         public event AsyncEventHandler<ChannelModerateV2Args>? ChannelModerateV2;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelModeratorArgs>? OnChannelModeratorAdd;
+        public event AsyncEventHandler<ChannelModeratorArgs>? ChannelModeratorAdd;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelModeratorArgs>? OnChannelModeratorRemove;
+        public event AsyncEventHandler<ChannelModeratorArgs>? ChannelModeratorRemove;
         /// <inheritdoc/>
         public event AsyncEventHandler<ChannelPointsAutomaticRewardRedemptionAddArgs>? ChannelPointsAutomaticRewardRedemptionAdd;
         /// <inheritdoc/>
         public event AsyncEventHandler<ChannelPointsAutomaticRewardRedemptionAddV2Args>? ChannelPointsAutomaticRewardRedemptionAddV2;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelPointsCustomRewardArgs>? OnChannelPointsCustomRewardAdd;
+        public event AsyncEventHandler<ChannelPointsCustomRewardArgs>? ChannelPointsCustomRewardAdd;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelPointsCustomRewardArgs>? OnChannelPointsCustomRewardUpdate;
+        public event AsyncEventHandler<ChannelPointsCustomRewardArgs>? ChannelPointsCustomRewardUpdate;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelPointsCustomRewardArgs>? OnChannelPointsCustomRewardRemove;
+        public event AsyncEventHandler<ChannelPointsCustomRewardArgs>? ChannelPointsCustomRewardRemove;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelPointsCustomRewardRedemptionArgs>? OnChannelPointsCustomRewardRedemptionAdd;
+        public event AsyncEventHandler<ChannelPointsCustomRewardRedemptionArgs>? ChannelPointsCustomRewardRedemptionAdd;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelPointsCustomRewardRedemptionArgs>? OnChannelPointsCustomRewardRedemptionUpdate;
+        public event AsyncEventHandler<ChannelPointsCustomRewardRedemptionArgs>? ChannelPointsCustomRewardRedemptionUpdate;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelPollBeginArgs>? OnChannelPollBegin;
+        public event AsyncEventHandler<ChannelPollBeginArgs>? ChannelPollBegin;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelPollEndArgs>? OnChannelPollEnd;
+        public event AsyncEventHandler<ChannelPollEndArgs>? ChannelPollEnd;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelPollProgressArgs>? OnChannelPollProgress;
+        public event AsyncEventHandler<ChannelPollProgressArgs>? ChannelPollProgress;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelPredictionBeginArgs>? OnChannelPredictionBegin;
+        public event AsyncEventHandler<ChannelPredictionBeginArgs>? ChannelPredictionBegin;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelPredictionEndArgs>? OnChannelPredictionEnd;
+        public event AsyncEventHandler<ChannelPredictionEndArgs>? ChannelPredictionEnd;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelPredictionLockArgs>? OnChannelPredictionLock;
+        public event AsyncEventHandler<ChannelPredictionLockArgs>? ChannelPredictionLock;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelPredictionProgressArgs>? OnChannelPredictionProgress;
+        public event AsyncEventHandler<ChannelPredictionProgressArgs>? ChannelPredictionProgress;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelRaidArgs>? OnChannelRaid;
+        public event AsyncEventHandler<ChannelRaidArgs>? ChannelRaid;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelShieldModeBeginArgs>? OnChannelShieldModeBegin;
+        public event AsyncEventHandler<ChannelShieldModeBeginArgs>? ChannelShieldModeBegin;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelShieldModeEndArgs>? OnChannelShieldModeEnd;
+        public event AsyncEventHandler<ChannelShieldModeEndArgs>? ChannelShieldModeEnd;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelShoutoutCreateArgs>? OnChannelShoutoutCreate;
+        public event AsyncEventHandler<ChannelShoutoutCreateArgs>? ChannelShoutoutCreate;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelShoutoutReceiveArgs>? OnChannelShoutoutReceive;
+        public event AsyncEventHandler<ChannelShoutoutReceiveArgs>? ChannelShoutoutReceive;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelSubscribeArgs>? OnChannelSubscribe;
+        public event AsyncEventHandler<ChannelSubscribeArgs>? ChannelSubscribe;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelSubscriptionEndArgs>? OnChannelSubscriptionEnd;
+        public event AsyncEventHandler<ChannelSubscriptionEndArgs>? ChannelSubscriptionEnd;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelSubscriptionGiftArgs>? OnChannelSubscriptionGift;
+        public event AsyncEventHandler<ChannelSubscriptionGiftArgs>? ChannelSubscriptionGift;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelSubscriptionMessageArgs>? OnChannelSubscriptionMessage;
+        public event AsyncEventHandler<ChannelSubscriptionMessageArgs>? ChannelSubscriptionMessage;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelUnbanArgs>? OnChannelUnban;
+        public event AsyncEventHandler<ChannelUnbanArgs>? ChannelUnban;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelUpdateArgs>? OnChannelUpdate;
-        /// <inheritdoc/>
-        public event AsyncEventHandler<OnErrorArgs>? OnError;
+        public event AsyncEventHandler<ChannelUpdateArgs>? ChannelUpdate;
         /// <inheritdoc/>
         public event AsyncEventHandler<ConduitShardDisabledArgs>? ConduitShardDisabled;
         /// <inheritdoc/>
-        public event AsyncEventHandler<DropEntitlementGrantArgs>? OnDropEntitlementGrant;
+        public event AsyncEventHandler<DropEntitlementGrantArgs>? DropEntitlementGrant;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ExtensionBitsTransactionCreateArgs>? OnExtensionBitsTransactionCreate;
+        public event AsyncEventHandler<ExtensionBitsTransactionCreateArgs>? ExtensionBitsTransactionCreate;
         /// <inheritdoc/>
-        public event AsyncEventHandler<RevocationArgs>? OnRevocation;
+        public event AsyncEventHandler<StreamOfflineArgs>? StreamOffline;
         /// <inheritdoc/>
-        public event AsyncEventHandler<StreamOfflineArgs>? OnStreamOffline;
+        public event AsyncEventHandler<StreamOnlineArgs>? StreamOnline;
         /// <inheritdoc/>
-        public event AsyncEventHandler<StreamOnlineArgs>? OnStreamOnline;
+        public event AsyncEventHandler<UserAuthorizationGrantArgs>? UserAuthorizationGrant;
         /// <inheritdoc/>
-        public event AsyncEventHandler<UserAuthorizationGrantArgs>? OnUserAuthorizationGrant;
+        public event AsyncEventHandler<UserAuthorizationRevokeArgs>? UserAuthorizationRevoke;
         /// <inheritdoc/>
-        public event AsyncEventHandler<UserAuthorizationRevokeArgs>? OnUserAuthorizationRevoke;
+        public event AsyncEventHandler<UserUpdateArgs>? UserUpdate;
         /// <inheritdoc/>
-        public event AsyncEventHandler<UserUpdateArgs>? OnUserUpdate;
+        public event AsyncEventHandler<ChannelChatClearArgs>? ChannelChatClear;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelChatClearArgs>? OnChannelChatClear;
+        public event AsyncEventHandler<ChannelChatClearUserMessageArgs>? ChannelChatClearUserMessage;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelChatClearUserMessageArgs>? OnChannelChatClearUserMessage;
+        public event AsyncEventHandler<ChannelChatMessageArgs>? ChannelChatMessage;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelChatMessageArgs>? OnChannelChatMessage;
+        public event AsyncEventHandler<ChannelChatMessageDeleteArgs>? ChannelChatMessageDelete;
         /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelChatMessageDeleteArgs>? OnChannelChatMessageDelete;
-        /// <inheritdoc/>
-        public event AsyncEventHandler<ChannelChatNotificationArgs>? OnChannelChatNotification;
+        public event AsyncEventHandler<ChannelChatNotificationArgs>? ChannelChatNotification;
         /// <inheritdoc/>
         public event AsyncEventHandler<ChannelChatSettingsUpdateArgs>? ChannelChatSettingsUpdate;
         /// <inheritdoc/>
@@ -177,14 +176,14 @@ namespace TwitchLib.EventSub.Webhooks
         /// <inheritdoc/>
         public event AsyncEventHandler<ChannelChatUserMessageUpdateArgs>? ChannelChatUserMessageUpdate;
         /// <inheritdoc/>
-        public event AsyncEventHandler<UserWhisperMessageArgs>? OnUserWhisperMessage;
+        public event AsyncEventHandler<UserWhisperMessageArgs>? UserWhisperMessage;
 
         /// <inheritdoc/>
         public async Task ProcessNotificationAsync(WebhookEventSubMetadata metadata, Stream body)
         {
             if (string.IsNullOrEmpty(metadata.SubscriptionType) || string.IsNullOrEmpty(metadata.SubscriptionVersion))
             {
-                await OnError.InvokeAsync(this, new OnErrorArgs { Reason = "Missing_Header", Message = "The Twitch-Eventsub-Subscription-Type or Twitch-Eventsub-Subscription-Version header was not found" });
+                await Error.InvokeAsync(this, new OnErrorArgs { Reason = "Missing_Header", Message = "The Twitch-Eventsub-Subscription-Type or Twitch-Eventsub-Subscription-Version header was not found" });
                 return;
             }
 
@@ -214,43 +213,43 @@ namespace TwitchLib.EventSub.Webhooks
                         await InvokeEventSubEvent<ChannelBitsUseArgs, EventSubNotificationPayload<ChannelBitUse>>(ChannelBitsUse);
                         break;
                     case ("channel.ban", "1"):
-                        await InvokeEventSubEvent<ChannelBanArgs, EventSubNotificationPayload<ChannelBan>>(OnChannelBan);
+                        await InvokeEventSubEvent<ChannelBanArgs, EventSubNotificationPayload<ChannelBan>>(ChannelBan);
                         break;
                     case ("channel.cheer", "1"):
-                        await InvokeEventSubEvent<ChannelCheerArgs, EventSubNotificationPayload<ChannelCheer>>(OnChannelCheer);
+                        await InvokeEventSubEvent<ChannelCheerArgs, EventSubNotificationPayload<ChannelCheer>>(ChannelCheer);
                         break;
                     case ("channel.charity_campaign.start", "1"):
-                        await InvokeEventSubEvent<ChannelCharityCampaignStartArgs, EventSubNotificationPayload<ChannelCharityCampaignStart>>(OnChannelCharityCampaignStart);
+                        await InvokeEventSubEvent<ChannelCharityCampaignStartArgs, EventSubNotificationPayload<ChannelCharityCampaignStart>>(ChannelCharityCampaignStart);
                         break;
                     case ("channel.charity_campaign.donate", "1"):
-                        await InvokeEventSubEvent<ChannelCharityCampaignDonateArgs, EventSubNotificationPayload<ChannelCharityCampaignDonate>>(OnChannelCharityCampaignDonate);
+                        await InvokeEventSubEvent<ChannelCharityCampaignDonateArgs, EventSubNotificationPayload<ChannelCharityCampaignDonate>>(ChannelCharityCampaignDonate);
                         break;
                     case ("channel.charity_campaign.progress", "1"):
-                        await InvokeEventSubEvent<ChannelCharityCampaignProgressArgs, EventSubNotificationPayload<ChannelCharityCampaignProgress>>(OnChannelCharityCampaignProgress);
+                        await InvokeEventSubEvent<ChannelCharityCampaignProgressArgs, EventSubNotificationPayload<ChannelCharityCampaignProgress>>(ChannelCharityCampaignProgress);
                         break;
                     case ("channel.charity_campaign.stop", "1"):
-                        await InvokeEventSubEvent<ChannelCharityCampaignStopArgs, EventSubNotificationPayload<ChannelCharityCampaignStop>>(OnChannelCharityCampaignStop);
+                        await InvokeEventSubEvent<ChannelCharityCampaignStopArgs, EventSubNotificationPayload<ChannelCharityCampaignStop>>(ChannelCharityCampaignStop);
                         break;
                     case ("channel.follow", "2"):
-                        await InvokeEventSubEvent<ChannelFollowArgs, EventSubNotificationPayload<ChannelFollow>>(OnChannelFollow);
+                        await InvokeEventSubEvent<ChannelFollowArgs, EventSubNotificationPayload<ChannelFollow>>(ChannelFollow);
                         break;
                     case ("channel.goal.begin", "1"):
-                        await InvokeEventSubEvent<ChannelGoalBeginArgs, EventSubNotificationPayload<ChannelGoalBegin>>(OnChannelGoalBegin);
+                        await InvokeEventSubEvent<ChannelGoalBeginArgs, EventSubNotificationPayload<ChannelGoalBegin>>(ChannelGoalBegin);
                         break;
                     case ("channel.goal.end", "1"):
-                        await InvokeEventSubEvent<ChannelGoalEndArgs, EventSubNotificationPayload<ChannelGoalEnd>>(OnChannelGoalEnd);
+                        await InvokeEventSubEvent<ChannelGoalEndArgs, EventSubNotificationPayload<ChannelGoalEnd>>(ChannelGoalEnd);
                         break;
                     case ("channel.goal.progress", "1"):
-                        await InvokeEventSubEvent<ChannelGoalProgressArgs, EventSubNotificationPayload<ChannelGoalProgress>>(OnChannelGoalProgress);
+                        await InvokeEventSubEvent<ChannelGoalProgressArgs, EventSubNotificationPayload<ChannelGoalProgress>>(ChannelGoalProgress);
                         break;
                     case ("channel.hype_train.begin", "2"):
-                        await InvokeEventSubEvent<ChannelHypeTrainBeginV2Args, EventSubNotificationPayload<HypeTrainBeginV2>>(OnChannelHypeTrainBeginV2);
+                        await InvokeEventSubEvent<ChannelHypeTrainBeginV2Args, EventSubNotificationPayload<HypeTrainBeginV2>>(ChannelHypeTrainBeginV2);
                         break;
                     case ("channel.hype_train.end", "2"):
-                        await InvokeEventSubEvent<ChannelHypeTrainEndV2Args, EventSubNotificationPayload<HypeTrainEndV2>>(OnChannelHypeTrainEndV2);
+                        await InvokeEventSubEvent<ChannelHypeTrainEndV2Args, EventSubNotificationPayload<HypeTrainEndV2>>(ChannelHypeTrainEndV2);
                         break;
                     case ("channel.hype_train.progress", "2"):
-                        await InvokeEventSubEvent<ChannelHypeTrainProgressV2Args, EventSubNotificationPayload<HypeTrainProgressV2>>(OnChannelHypeTrainProgressV2);
+                        await InvokeEventSubEvent<ChannelHypeTrainProgressV2Args, EventSubNotificationPayload<HypeTrainProgressV2>>(ChannelHypeTrainProgressV2);
                         break;
                     case ("channel.moderate", "1"):
                         await InvokeEventSubEvent<ChannelModerateArgs, EventSubNotificationPayload<ChannelModerate>>(ChannelModerate);
@@ -259,10 +258,10 @@ namespace TwitchLib.EventSub.Webhooks
                         await InvokeEventSubEvent<ChannelModerateV2Args, EventSubNotificationPayload<ChannelModerateV2>>(ChannelModerateV2);
                         break;
                     case ("channel.moderator.add", "1"):
-                        await InvokeEventSubEvent<ChannelModeratorArgs, EventSubNotificationPayload<ChannelModerator>>(OnChannelModeratorAdd);
+                        await InvokeEventSubEvent<ChannelModeratorArgs, EventSubNotificationPayload<ChannelModerator>>(ChannelModeratorAdd);
                         break;
                     case ("channel.moderator.remove", "1"):
-                        await InvokeEventSubEvent<ChannelModeratorArgs, EventSubNotificationPayload<ChannelModerator>>(OnChannelModeratorRemove);
+                        await InvokeEventSubEvent<ChannelModeratorArgs, EventSubNotificationPayload<ChannelModerator>>(ChannelModeratorRemove);
                         break;
                     case ("channel.channel_points_automatic_reward_redemption.add", "1"):
                         await InvokeEventSubEvent<ChannelPointsAutomaticRewardRedemptionAddArgs, EventSubNotificationPayload<ChannelPointsAutomaticRewardRedemption>>(ChannelPointsAutomaticRewardRedemptionAdd);
@@ -271,112 +270,112 @@ namespace TwitchLib.EventSub.Webhooks
                         await InvokeEventSubEvent<ChannelPointsAutomaticRewardRedemptionAddV2Args, EventSubNotificationPayload<ChannelPointsAutomaticRewardRedemptionV2>>(ChannelPointsAutomaticRewardRedemptionAddV2);
                         break;
                     case ("channel.channel_points_custom_reward.add", "1"):
-                        await InvokeEventSubEvent<ChannelPointsCustomRewardArgs, EventSubNotificationPayload<ChannelPointsCustomReward>>(OnChannelPointsCustomRewardAdd);
+                        await InvokeEventSubEvent<ChannelPointsCustomRewardArgs, EventSubNotificationPayload<ChannelPointsCustomReward>>(ChannelPointsCustomRewardAdd);
                         break;
                     case ("channel.channel_points_custom_reward.remove", "1"):
-                        await InvokeEventSubEvent<ChannelPointsCustomRewardArgs, EventSubNotificationPayload<ChannelPointsCustomReward>>(OnChannelPointsCustomRewardRemove);
+                        await InvokeEventSubEvent<ChannelPointsCustomRewardArgs, EventSubNotificationPayload<ChannelPointsCustomReward>>(ChannelPointsCustomRewardRemove);
                         break;
                     case ("channel.channel_points_custom_reward.update", "1"):
-                        await InvokeEventSubEvent<ChannelPointsCustomRewardArgs, EventSubNotificationPayload<ChannelPointsCustomReward>>(OnChannelPointsCustomRewardUpdate);
+                        await InvokeEventSubEvent<ChannelPointsCustomRewardArgs, EventSubNotificationPayload<ChannelPointsCustomReward>>(ChannelPointsCustomRewardUpdate);
                         break;
                     case ("channel.channel_points_custom_reward_redemption.add", "1"):
-                        await InvokeEventSubEvent<ChannelPointsCustomRewardRedemptionArgs, EventSubNotificationPayload<ChannelPointsCustomRewardRedemption>>(OnChannelPointsCustomRewardRedemptionAdd);
+                        await InvokeEventSubEvent<ChannelPointsCustomRewardRedemptionArgs, EventSubNotificationPayload<ChannelPointsCustomRewardRedemption>>(ChannelPointsCustomRewardRedemptionAdd);
                         break;
                     case ("channel.channel_points_custom_reward_redemption.update", "1"):
-                        await InvokeEventSubEvent<ChannelPointsCustomRewardRedemptionArgs, EventSubNotificationPayload<ChannelPointsCustomRewardRedemption>>(OnChannelPointsCustomRewardRedemptionUpdate);
+                        await InvokeEventSubEvent<ChannelPointsCustomRewardRedemptionArgs, EventSubNotificationPayload<ChannelPointsCustomRewardRedemption>>(ChannelPointsCustomRewardRedemptionUpdate);
                         break;
                     case ("channel.poll.begin", "1"):
-                        await InvokeEventSubEvent<ChannelPollBeginArgs, EventSubNotificationPayload<ChannelPollBegin>>(OnChannelPollBegin);
+                        await InvokeEventSubEvent<ChannelPollBeginArgs, EventSubNotificationPayload<ChannelPollBegin>>(ChannelPollBegin);
                         break;
                     case ("channel.poll.end", "1"):
-                        await InvokeEventSubEvent<ChannelPollEndArgs, EventSubNotificationPayload<ChannelPollEnd>>(OnChannelPollEnd);
+                        await InvokeEventSubEvent<ChannelPollEndArgs, EventSubNotificationPayload<ChannelPollEnd>>(ChannelPollEnd);
                         break;
                     case ("channel.poll.progress", "1"):
-                        await InvokeEventSubEvent<ChannelPollProgressArgs, EventSubNotificationPayload<ChannelPollProgress>>(OnChannelPollProgress);
+                        await InvokeEventSubEvent<ChannelPollProgressArgs, EventSubNotificationPayload<ChannelPollProgress>>(ChannelPollProgress);
                         break;
                     case ("channel.prediction.begin", "1"):
-                        await InvokeEventSubEvent<ChannelPredictionBeginArgs, EventSubNotificationPayload<ChannelPredictionBegin>>(OnChannelPredictionBegin);
+                        await InvokeEventSubEvent<ChannelPredictionBeginArgs, EventSubNotificationPayload<ChannelPredictionBegin>>(ChannelPredictionBegin);
                         break;
                     case ("channel.prediction.end", "1"):
-                        await InvokeEventSubEvent<ChannelPredictionEndArgs, EventSubNotificationPayload<ChannelPredictionEnd>>(OnChannelPredictionEnd);
+                        await InvokeEventSubEvent<ChannelPredictionEndArgs, EventSubNotificationPayload<ChannelPredictionEnd>>(ChannelPredictionEnd);
                         break;
                     case ("channel.prediction.lock", "1"):
-                        await InvokeEventSubEvent<ChannelPredictionLockArgs, EventSubNotificationPayload<ChannelPredictionLock>>(OnChannelPredictionLock);
+                        await InvokeEventSubEvent<ChannelPredictionLockArgs, EventSubNotificationPayload<ChannelPredictionLock>>(ChannelPredictionLock);
                         break;
                     case ("channel.prediction.progress", "1"):
-                        await InvokeEventSubEvent<ChannelPredictionProgressArgs, EventSubNotificationPayload<ChannelPredictionProgress>>(OnChannelPredictionProgress);
+                        await InvokeEventSubEvent<ChannelPredictionProgressArgs, EventSubNotificationPayload<ChannelPredictionProgress>>(ChannelPredictionProgress);
                         break;
                     case ("channel.raid", "1"):
-                        await InvokeEventSubEvent<ChannelRaidArgs, EventSubNotificationPayload<ChannelRaid>>(OnChannelRaid);
+                        await InvokeEventSubEvent<ChannelRaidArgs, EventSubNotificationPayload<ChannelRaid>>(ChannelRaid);
                         break;
                     case ("channel.shield_mode.begin", "1"):
-                        await InvokeEventSubEvent<ChannelShieldModeBeginArgs, EventSubNotificationPayload<ChannelShieldModeBegin>>(OnChannelShieldModeBegin);
+                        await InvokeEventSubEvent<ChannelShieldModeBeginArgs, EventSubNotificationPayload<ChannelShieldModeBegin>>(ChannelShieldModeBegin);
                         break;
                     case ("channel.shield_mode.end", "1"):
-                        await InvokeEventSubEvent<ChannelShieldModeEndArgs, EventSubNotificationPayload<ChannelShieldModeEnd>>(OnChannelShieldModeEnd);
+                        await InvokeEventSubEvent<ChannelShieldModeEndArgs, EventSubNotificationPayload<ChannelShieldModeEnd>>(ChannelShieldModeEnd);
                         break;
                     case ("channel.shoutout.create", "1"):
-                        await InvokeEventSubEvent<ChannelShoutoutCreateArgs, EventSubNotificationPayload<ChannelShoutoutCreate>>(OnChannelShoutoutCreate);
+                        await InvokeEventSubEvent<ChannelShoutoutCreateArgs, EventSubNotificationPayload<ChannelShoutoutCreate>>(ChannelShoutoutCreate);
                         break;
                     case ("channel.shoutout.receive", "1"):
-                        await InvokeEventSubEvent<ChannelShoutoutReceiveArgs, EventSubNotificationPayload<ChannelShoutoutReceive>>(OnChannelShoutoutReceive);
+                        await InvokeEventSubEvent<ChannelShoutoutReceiveArgs, EventSubNotificationPayload<ChannelShoutoutReceive>>(ChannelShoutoutReceive);
                         break;
                     case ("channel.subscribe", "1"):
-                        await InvokeEventSubEvent<ChannelSubscribeArgs, EventSubNotificationPayload<ChannelSubscribe>>(OnChannelSubscribe);
+                        await InvokeEventSubEvent<ChannelSubscribeArgs, EventSubNotificationPayload<ChannelSubscribe>>(ChannelSubscribe);
                         break;
                     case ("channel.subscription.end", "1"):
-                        await InvokeEventSubEvent<ChannelSubscriptionEndArgs, EventSubNotificationPayload<ChannelSubscriptionEnd>>(OnChannelSubscriptionEnd);
+                        await InvokeEventSubEvent<ChannelSubscriptionEndArgs, EventSubNotificationPayload<ChannelSubscriptionEnd>>(ChannelSubscriptionEnd);
                         break;
                     case ("channel.subscription.gift", "1"):
-                        await InvokeEventSubEvent<ChannelSubscriptionGiftArgs, EventSubNotificationPayload<ChannelSubscriptionGift>>(OnChannelSubscriptionGift);
+                        await InvokeEventSubEvent<ChannelSubscriptionGiftArgs, EventSubNotificationPayload<ChannelSubscriptionGift>>(ChannelSubscriptionGift);
                         break;
                     case ("channel.subscription.message", "1"):
-                        await InvokeEventSubEvent<ChannelSubscriptionMessageArgs, EventSubNotificationPayload<ChannelSubscriptionMessage>>(OnChannelSubscriptionMessage);
+                        await InvokeEventSubEvent<ChannelSubscriptionMessageArgs, EventSubNotificationPayload<ChannelSubscriptionMessage>>(ChannelSubscriptionMessage);
                         break;
                     case ("channel.unban", "1"):
-                        await InvokeEventSubEvent<ChannelUnbanArgs, EventSubNotificationPayload<ChannelUnban>>(OnChannelUnban);
+                        await InvokeEventSubEvent<ChannelUnbanArgs, EventSubNotificationPayload<ChannelUnban>>(ChannelUnban);
                         break;
                     case ("channel.update", "2"):
-                        await InvokeEventSubEvent<ChannelUpdateArgs, EventSubNotificationPayload<ChannelUpdate>>(OnChannelUpdate);
+                        await InvokeEventSubEvent<ChannelUpdateArgs, EventSubNotificationPayload<ChannelUpdate>>(ChannelUpdate);
                         break;
                     case ("drop.entitlement.grant", "1"):
-                        await InvokeEventSubEvent<DropEntitlementGrantArgs, BatchedNotificationPayload<DropEntitlementGrant>>(OnDropEntitlementGrant);
+                        await InvokeEventSubEvent<DropEntitlementGrantArgs, BatchedNotificationPayload<DropEntitlementGrant>>(DropEntitlementGrant);
                         break;
                     case ("conduit.shard.disabled", "1"):
                         await InvokeEventSubEvent<ConduitShardDisabledArgs, EventSubNotificationPayload<ConduitShardDisabled>>(ConduitShardDisabled);
                         break;
                     case ("extension.bits_transaction.create", "1"):
-                        await InvokeEventSubEvent<ExtensionBitsTransactionCreateArgs, EventSubNotificationPayload<ExtensionBitsTransactionCreate>>(OnExtensionBitsTransactionCreate);
+                        await InvokeEventSubEvent<ExtensionBitsTransactionCreateArgs, EventSubNotificationPayload<ExtensionBitsTransactionCreate>>(ExtensionBitsTransactionCreate);
                         break;
                     case ("stream.offline", "1"):
-                        await InvokeEventSubEvent<StreamOfflineArgs, EventSubNotificationPayload<StreamOffline>>(OnStreamOffline);
+                        await InvokeEventSubEvent<StreamOfflineArgs, EventSubNotificationPayload<StreamOffline>>(StreamOffline);
                         break;
                     case ("stream.online", "1"):
-                        await InvokeEventSubEvent<StreamOnlineArgs, EventSubNotificationPayload<StreamOnline>>(OnStreamOnline);
+                        await InvokeEventSubEvent<StreamOnlineArgs, EventSubNotificationPayload<StreamOnline>>(StreamOnline);
                         break;
                     case ("user.authorization.grant", "1"):
-                        await InvokeEventSubEvent<UserAuthorizationGrantArgs, EventSubNotificationPayload<UserAuthorizationGrant>>(OnUserAuthorizationGrant);
+                        await InvokeEventSubEvent<UserAuthorizationGrantArgs, EventSubNotificationPayload<UserAuthorizationGrant>>(UserAuthorizationGrant);
                         break;
                     case ("user.authorization.revoke", "1"):
-                        await InvokeEventSubEvent<UserAuthorizationRevokeArgs, EventSubNotificationPayload<UserAuthorizationRevoke>>(OnUserAuthorizationRevoke);
+                        await InvokeEventSubEvent<UserAuthorizationRevokeArgs, EventSubNotificationPayload<UserAuthorizationRevoke>>(UserAuthorizationRevoke);
                         break;
                     case ("user.update", "1"):
-                        await InvokeEventSubEvent<UserUpdateArgs, EventSubNotificationPayload<UserUpdate>>(OnUserUpdate);
+                        await InvokeEventSubEvent<UserUpdateArgs, EventSubNotificationPayload<UserUpdate>>(UserUpdate);
                         break;
                     case ("channel.chat.clear", "1"):
-                        await InvokeEventSubEvent<ChannelChatClearArgs, EventSubNotificationPayload<ChannelChatClear>>(OnChannelChatClear);
+                        await InvokeEventSubEvent<ChannelChatClearArgs, EventSubNotificationPayload<ChannelChatClear>>(ChannelChatClear);
                         break;
                     case ("channel.chat.clear_user_messages", "1"):
-                        await InvokeEventSubEvent<ChannelChatClearUserMessageArgs, EventSubNotificationPayload<ChannelChatClearUserMessage>>(OnChannelChatClearUserMessage);
+                        await InvokeEventSubEvent<ChannelChatClearUserMessageArgs, EventSubNotificationPayload<ChannelChatClearUserMessage>>(ChannelChatClearUserMessage);
                         break;
                     case ("channel.chat.message", "1"):
-                        await InvokeEventSubEvent<ChannelChatMessageArgs, EventSubNotificationPayload<ChannelChatMessage>>(OnChannelChatMessage);
+                        await InvokeEventSubEvent<ChannelChatMessageArgs, EventSubNotificationPayload<ChannelChatMessage>>(ChannelChatMessage);
                         break;
                     case ("channel.chat.message_delete", "1"):
-                        await InvokeEventSubEvent<ChannelChatMessageDeleteArgs, EventSubNotificationPayload<ChannelChatMessageDelete>>(OnChannelChatMessageDelete);
+                        await InvokeEventSubEvent<ChannelChatMessageDeleteArgs, EventSubNotificationPayload<ChannelChatMessageDelete>>(ChannelChatMessageDelete);
                         break;
                     case ("channel.chat.notification", "1"):
-                        await InvokeEventSubEvent<ChannelChatNotificationArgs, EventSubNotificationPayload<ChannelChatNotification>>(OnChannelChatNotification);
+                        await InvokeEventSubEvent<ChannelChatNotificationArgs, EventSubNotificationPayload<ChannelChatNotification>>(ChannelChatNotification);
                         break;
                     case ("channel.chat_settings.update", "1"):
                         await InvokeEventSubEvent<ChannelChatSettingsUpdateArgs, EventSubNotificationPayload<ChannelChatSettingsUpdate>>(ChannelChatSettingsUpdate);
@@ -388,7 +387,7 @@ namespace TwitchLib.EventSub.Webhooks
                         await InvokeEventSubEvent<ChannelChatUserMessageUpdateArgs, EventSubNotificationPayload<ChannelChatUserMessageUpdate>>(ChannelChatUserMessageUpdate);
                         break;
                     case ("user.whisper.message", "1"):
-                        await InvokeEventSubEvent<UserWhisperMessageArgs, EventSubNotificationPayload<UserWhisperMessage>>(OnUserWhisperMessage);
+                        await InvokeEventSubEvent<UserWhisperMessageArgs, EventSubNotificationPayload<UserWhisperMessage>>(UserWhisperMessage);
                         break;
                     default:
                         await InvokeEventSubEvent<UnknownEventSubNotificationArgs, EventSubNotificationPayload<JsonElement>>(UnknownEventSubNotification);
@@ -397,7 +396,7 @@ namespace TwitchLib.EventSub.Webhooks
             }
             catch (Exception ex)
             {
-                await OnError.InvokeAsync(this, new OnErrorArgs { Reason = "Application_Error", Message = ex.Message });
+                await Error.InvokeAsync(this, new OnErrorArgs { Reason = "Application_Error", Message = ex.Message });
             }
 
             async Task InvokeEventSubEvent<TEvent, TModel>(AsyncEventHandler<TEvent>? asyncEventHandler)
@@ -415,11 +414,11 @@ namespace TwitchLib.EventSub.Webhooks
             try
             {
                 var notification = await JsonSerializer.DeserializeAsync<EventSubNotificationPayload<object>>(body, _jsonSerializerOptions);
-                await OnRevocation.InvokeAsync(this, new RevocationArgs { Metadata = metadata, Notification = notification! });
+                await Revocation.InvokeAsync(this, new RevocationArgs { Metadata = metadata, Notification = notification! });
             }
             catch (Exception ex)
             {
-                await OnError.InvokeAsync(this, new OnErrorArgs { Reason = "Application_Error", Message = ex.Message });
+                await Error.InvokeAsync(this, new OnErrorArgs { Reason = "Application_Error", Message = ex.Message });
             }
         }
     }


### PR DESCRIPTION
This PR contains changes to remove the differences between WebSocket and Webhook projects (e.g. Webhook used the `On` prefix on events while Websocket omitted it).

changes:
- replace `Headers` with strongly type class `WebhookEventSubMetadata`
- drop `On prefix on events